### PR TITLE
use directory name instead of filename in LD_LIBRARY_PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -200,7 +200,7 @@ set-env GEOS_LIBRARY_PATH $GEOS_LIBRARY_PATH
 set-env PROJ4_LIBRARY_PATH $PROJ4_LIBRARY_PATH
 set-env GDAL_LIBRARY_PATH $GDAL_LIBRARY_PATH
 set-env LIBRARY_PATH /app/.heroku/vendor/lib:/app/.heroku/python/lib
-set-env LD_LIBRARY_PATH '/app/.heroku/vendor/lib:/app/.heroku/python/lib:$GEOS_LIBRARY_PATH/lib:$PROJ4_LIBRARY_PATH/lib:$GDAL_LIBRARY_PATH/lib:$LD_LIBRARY_PATH'
+set-env LD_LIBRARY_PATH '/app/.heroku/vendor/lib:/app/.heroku/python/lib:$(dirname "$GEOS_LIBRARY_PATH"):$PROJ4_LIBRARY_PATH:$(dirname "$GDAL_LIBRARY_PATH"):$LD_LIBRARY_PATH'
 set-default-env LANG en_US.UTF-8
 set-default-env PYTHONHASHSEED random
 set-default-env PYTHONPATH /app/

--- a/bin/compile
+++ b/bin/compile
@@ -200,7 +200,7 @@ set-env GEOS_LIBRARY_PATH $GEOS_LIBRARY_PATH
 set-env PROJ4_LIBRARY_PATH $PROJ4_LIBRARY_PATH
 set-env GDAL_LIBRARY_PATH $GDAL_LIBRARY_PATH
 set-env LIBRARY_PATH /app/.heroku/vendor/lib:/app/.heroku/python/lib
-set-env LD_LIBRARY_PATH '/app/.heroku/vendor/lib:/app/.heroku/python/lib:$(dirname "$GEOS_LIBRARY_PATH"):$PROJ4_LIBRARY_PATH:$(dirname "$GDAL_LIBRARY_PATH"):$LD_LIBRARY_PATH'
+set-env LD_LIBRARY_PATH '/app/.heroku/vendor/lib:/app/.heroku/python/lib:$(dirname "$GEOS_LIBRARY_PATH"):$PROJ4_LIBRARY_PATH/lib:$(dirname "$GDAL_LIBRARY_PATH"):$LD_LIBRARY_PATH'
 set-default-env LANG en_US.UTF-8
 set-default-env PYTHONHASHSEED random
 set-default-env PYTHONPATH /app/


### PR DESCRIPTION
Solves a missing library error:  OSError: libgeos-3.4.2.so: cannot open shared object file: No such file or directory

As described in:

https://github.com/dulaccc/heroku-buildpack-geodjango/issues/4